### PR TITLE
Fix bug with json key names that have prefixes equal to some a CMake keyword.

### DIFF
--- a/JSONParser.cmake
+++ b/JSONParser.cmake
@@ -144,7 +144,7 @@ macro(_sbeParseNameValue prefix)
                 string(SUBSTRING "${json_string}" ${json_index} 1 json_char)
             endif()
         
-            set(json_name "${json_name}${json_char}")
+            string(APPEND json_name "${json_char}")
         endif()
         
         # check if name starts


### PR DESCRIPTION
If while parsing, `json_name` is set to an intermediate (or final) value that is equal to some cmake keyword (e.g. "CACHE"), then using set will fail. This changes the operation to a string append.